### PR TITLE
Update fly.io emoji, fix spelling, add alternative way to change configured cloudflare worker server

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     env:
-      NODE_VERSION: 17
+      NODE_VERSION: 16
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     env:
-      NODE_VERSION: 18
+      NODE_VERSION: 17
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,17 +20,17 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     env:
-      NODE_VERSION: 14
+      NODE_VERSION: 18
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: 🚚 Get latest code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Runs a single command using the runners shell
       - name: 🧰 Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/docs/dns/introduction.md
+++ b/docs/dns/introduction.md
@@ -8,7 +8,7 @@ Rethink**DNS** is [DNS Resolver](https://www.cloudflare.com/learning/dns/what-is
 
 You can configure Rethink**DNS** in the companion [firewall app](firewall) or even in your own device / internet browser that supports [Secure DNS](https://wikipedia.org/wiki/DNS_over_HTTPS) (aka DNS over HTTPS). See below on [how to configure](#how-to).
 
-RethinkDNS is private, secure, and fast DNS resolver and has 170+ pre-defined blacklists for you to configure.
+RethinkDNS is private, secure, and fast DNS resolver and has 190+ pre-defined blacklists for you to configure.
 
 With our paid plans (coming soon), you'll also be able to define your own custom blocklists that can be configured with Rethink**DNS**. The paid plan will also allow you to store you dns logs and view analytics, all in the cloud. You will be able to analyse your DNS requests and read through aggregated reports.
 

--- a/docs/dns/open-source.md
+++ b/docs/dns/open-source.md
@@ -44,7 +44,7 @@ Rethink serverless can be hosted to cloudflare. User will be liable for cloudfla
 		- if your new DOH resolver url is `example.dns.resolver.com/dns-query/resolve`
 		- change below variables and click on save button
 			`CF_DNS_RESOLVER_URL = example.dns.resolver.com/dns-query/resolve`
-                - alternatively, you can modify your CF_DNS_RESOLVER_URL in your forked serverless-dns repo. Head to src/core/env.js and modify either your CF_DNS_RESOLVER_URL or CF_DNS_RESOLVER_URL_2 server
+                - alternatively, you can modify your `CF_DNS_RESOLVER_URL` in your forked serverless-dns repo. Head to src/core/env.js and modify either your `CF_DNS_RESOLVER_URL or CF_DNS_RESOLVER_URL_2` server
 
 
 ### Using Deno-Deploy {#deno-deploy}

--- a/docs/dns/open-source.md
+++ b/docs/dns/open-source.md
@@ -25,7 +25,7 @@ Rethink serverless can be hosted to cloudflare. User will be liable for cloudfla
 		to `example.com`.
 	- To configure your dns level blocking visit to `example.com/configure` which
 		will take to configuration page, which currently contains 191 blocklists with
-		5 Million blockable domains in category like notracking, dating, gambling,
+		~13 Million blockable domains in category like notracking, dating, gambling,
 		privacy, porn, cryptojacking, security ...
 	- Navigate through and select your blocklists.
 	- Once selected you can find your domain name `example.com` followed by

--- a/docs/dns/open-source.md
+++ b/docs/dns/open-source.md
@@ -44,7 +44,7 @@ Rethink serverless can be hosted to cloudflare. User will be liable for cloudfla
 		- if your new DOH resolver url is `example.dns.resolver.com/dns-query/resolve`
 		- change below variables and click on save button
 			`CF_DNS_RESOLVER_URL = example.dns.resolver.com/dns-query/resolve`
-                - alternatively, you can modify your `CF_DNS_RESOLVER_URL` in your forked serverless-dns repo. Head to src/core/env.js and modify either your `CF_DNS_RESOLVER_URL or CF_DNS_RESOLVER_URL_2` server
+                - alternatively, you can modify your `CF_DNS_RESOLVER_URL` in your forked serverless-dns repo. Head to src/core/env.js and modify either your `CF_DNS_RESOLVER_URL` or `CF_DNS_RESOLVER_URL_2` server
 
 
 ### Using Deno-Deploy {#deno-deploy}

--- a/docs/dns/open-source.md
+++ b/docs/dns/open-source.md
@@ -12,7 +12,7 @@ This serverless DNS can be hosted to three platforms: Cloudflare, Deno-Deploy an
 | ------------- | ---------- | ----------------- | --------------------------------- |
 | ⛅ Cloudflare  | Easy       | HTTPS             | [Read Instructions](#cloudflare)  |
 | 🦕 Deno Deploy | Moderate   | HTTPS             | [Read Instructions](#deno-deploy) |
-| 🪰 Fly         | Hard       | TLS & HTTPS       | [Read Instructions](#fly-io)      |
+| 🪂 Fly         | Hard       | TLS & HTTPS       | [Read Instructions](#fly-io)      |
 
 ### Using Cloudflare {#cloudflare}
 
@@ -24,8 +24,8 @@ Rethink serverless can be hosted to cloudflare. User will be liable for cloudfla
 	- Once the hosting is successful, lets consider rethink serverless dns is hosted
 		to `example.com`.
 	- To configure your dns level blocking visit to `example.com/configure` which
-		will take to configuration page, which currently contains 171 blocklists with
-		5 Million too block domains in category like notracking, dating, gambling,
+		will take to configuration page, which currently contains 191 blocklists with
+		5 Million blockable domains in category like notracking, dating, gambling,
 		privacy, porn, cryptojacking, security ...
 	- Navigate through and select your blocklists.
 	- Once selected you can find your domain name `example.com` followed by
@@ -44,6 +44,7 @@ Rethink serverless can be hosted to cloudflare. User will be liable for cloudfla
 		- if your new DOH resolver url is `example.dns.resolver.com/dns-query/resolve`
 		- change below variables and click on save button
 			`CF_DNS_RESOLVER_URL = example.dns.resolver.com/dns-query/resolve`
+                - alternatively, you can modify your CF_DNS_RESOLVER_URL in your forked serverless-dns repo. Head to src/core/env.js and modify either your CF_DNS_RESOLVER_URL or CF_DNS_RESOLVER_URL_2 server
 
 
 ### Using Deno-Deploy {#deno-deploy}


### PR DESCRIPTION
The cloudflare documentation was confusing to me when I was at the time of switching my queryed dns server. Since it uses google as a backup and even though I changed my dns in cloudflare using the way in the docs, I was still going through google’s dns. This adds an alternative way to change it which worked for me to change from google dns.